### PR TITLE
fixed powerups behavior

### DIFF
--- a/unityTree/Assets/_Scripts/DePowerUpScript.cs
+++ b/unityTree/Assets/_Scripts/DePowerUpScript.cs
@@ -10,7 +10,7 @@ public class DePowerUpScript : MonoBehaviour {
         if (other.tag == "Player")
         {
             hud = GameObject.Find("Main Camera").GetComponent<HUDScript>();
-            hud.IncreaseScore(-200);
+            hud.IncreaseScore(-5);
             Destroy(this.gameObject);
         }
     }

--- a/unityTree/Assets/_Scripts/PowerUpScript.cs
+++ b/unityTree/Assets/_Scripts/PowerUpScript.cs
@@ -10,7 +10,7 @@ public class PowerUpScript : MonoBehaviour {
         if(other.tag =="Player")
         {
             hud = GameObject.Find("Main Camera").GetComponent<HUDScript>();
-            hud.IncreaseScore(100);
+            hud.IncreaseScore(5);
             Destroy(this.gameObject);
         }
     }


### PR DESCRIPTION
Fixed powerups behavior. Now when the player picks up either decrease or increase power ups it change the score in a more reasonable way.
